### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/semantic-release/Dockerfile
+++ b/semantic-release/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILDARCH
 
 RUN \
   apk add --no-cache --no-progress git git-lfs openssh && \
-  yarn global add semantic-release @qiwi/multi-semantic-release @semantic-release/github @semantic-release/npm @semantic-release/git @semantic-release/changelog @semantic-release/gitlab @semantic-release/exec semantic-release-docker @google/semantic-release-replace-plugin && \
+  yarn global add semantic-release @qiwi/multi-semantic-release @semantic-release/github @semantic-release/npm @semantic-release/git @semantic-release/changelog @semantic-release/gitlab @semantic-release/exec semantic-release-docker semantic-release-replace-plugin && \
   # # https://github.com/npm/cli/issues/4605
   # npm i -g npm@8.4
   npm -g config set workspaces-update false && \


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).